### PR TITLE
fix: Retrieve subtask from Task Range response

### DIFF
--- a/src/application/dtos/TaskSubtaskSummaryDto.ts
+++ b/src/application/dtos/TaskSubtaskSummaryDto.ts
@@ -1,11 +1,14 @@
+import type { SubTaskEntity } from "../../core/entities/SubTaskEntity";
 import type { UserEntity } from "../../core/entities/UserEntity";
 
 export class TaskSubtaskSummaryDto {
 	constructor(
 		public id: string,
 		public name: string,
+		public description: string,
 		public assignedTo: UserEntity[],
 		public completed: boolean,
 		public dueToday: boolean,
+		public subTasks?: SubTaskEntity[],
 	) {}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ async function main() {
 		const rangeSummary = await taskSummaryService.getRangeSummaryAsync(
 			EnvManager.CLICKUP_WORKSPACE_ID,
 			true,
-			new Date("2025-08-11"),
+			new Date("2025-08-21"),
 			new Date("2025-08-31"),
 		);
 		console.log("RangeSummary", rangeSummary);

--- a/src/infrastructure/services/TaskSummaryService.ts
+++ b/src/infrastructure/services/TaskSummaryService.ts
@@ -27,66 +27,43 @@ export class TaskSummaryService implements ITaskSummaryService {
 			endDate,
 		);
 
-		const completedToday = this.getCompletedSubtasksForRange(
-			tasks,
-			startDate,
-			endDate,
-		);
-		const missedToday = this.getMissedSubtasksForRange(
-			tasks,
-			startDate,
-			endDate,
-		);
+		const completedToday = this.getCompletedSubtasksForRange(tasks);
+		const missedToday = this.getMissedSubtasksForRange(tasks);
 
 		return new TasksSummaryDto(tasks.length, completedToday, missedToday);
 	}
 
-	private getCompletedSubtasksForRange(
-		tasks: TaskEntity[],
-		startDate: Date,
-		endDate: Date,
-	) {
+	private getCompletedSubtasksForRange(tasks: TaskEntity[]) {
 		return tasks
 			.filter((task) => this.taskDomainService.isCompleted(task))
-			.filter(
-				(task) =>
-					task.dueDate &&
-					task.dueDate.getTime() >= startDate.getTime() &&
-					task.dueDate.getTime() <= endDate.getTime(),
-			)
+
 			.map(
 				(task) =>
 					new TaskSubtaskSummaryDto(
 						task.id.toString(),
 						task.name,
+						task.description,
 						task.assignees,
 						true,
 						true,
+						task.subtasks,
 					),
 			);
 	}
 
-	private getMissedSubtasksForRange(
-		tasks: TaskEntity[],
-		startDate: Date,
-		endDate: Date,
-	) {
+	private getMissedSubtasksForRange(tasks: TaskEntity[]) {
 		return tasks
-			.filter((task) => task.status !== TaskStatusEnum.COMPLETED)
-			.filter(
-				(task) =>
-					task.dueDate &&
-					task.dueDate.getTime() >= startDate.getTime() &&
-					task.dueDate.getTime() <= endDate.getTime(),
-			)
+			.filter((task) => !this.taskDomainService.isCompleted(task))
 			.map(
 				(task) =>
 					new TaskSubtaskSummaryDto(
 						task.id.toString(),
 						task.name,
+						task.description,
 						task.assignees,
 						false,
 						true,
+						task.subtasks,
 					),
 			);
 	}
@@ -152,9 +129,11 @@ export class TaskSummaryService implements ITaskSummaryService {
 					new TaskSubtaskSummaryDto(
 						st.id.toString(),
 						st.name,
+						st.description,
 						taskAssignee,
 						true,
 						true,
+						st.subtasks,
 					),
 			);
 	}
@@ -180,9 +159,11 @@ export class TaskSummaryService implements ITaskSummaryService {
 					new TaskSubtaskSummaryDto(
 						st.id.toString(),
 						st.name,
+						st.description,
 						taskAssignee,
 						false,
 						true,
+						st.subtasks,
 					),
 			);
 	}


### PR DESCRIPTION
This pull request introduces several improvements to the task summary and subtask handling logic, focusing on more accurate data mapping, enhanced API integration, and improved DTO structure. The main updates include changes to how subtasks are fetched and represented, as well as simplification of service methods for determining completed and missed subtasks.

**DTO and Data Structure Enhancements:**

* Added `description` and optional `subTasks` fields to the `TaskSubtaskSummaryDto` class, allowing for richer task and subtask summaries.
* Updated all usages of `TaskSubtaskSummaryDto` in `TaskSummaryService` to include the new `description` and `subtasks` fields when creating summary DTOs. [[1]](diffhunk://#diff-a2c78dff17e06d5f80404a54d95301cf977177cdc5c3379aa3adb2db523f26e2L30-R66) [[2]](diffhunk://#diff-a2c78dff17e06d5f80404a54d95301cf977177cdc5c3379aa3adb2db523f26e2R132-R136) [[3]](diffhunk://#diff-a2c78dff17e06d5f80404a54d95301cf977177cdc5c3379aa3adb2db523f26e2R162-R166)

**API Integration and Repository Logic:**

* Modified the `ClickUpTaskRepository` to use ISO date strings and updated parameter names for the ClickUp API, and changed how subtasks are requested by making additional API calls when `includeSubtasks` is true. [[1]](diffhunk://#diff-e3f613202b115a9b665b8fd69bde3b1421fc174e8f05cc3c60cee9eddcbe5ad1L22-R25) [[2]](diffhunk://#diff-e3f613202b115a9b665b8fd69bde3b1421fc174e8f05cc3c60cee9eddcbe5ad1L32-R46)

**Service Logic Simplification:**

* Simplified the `getCompletedSubtasksForRange` and `getMissedSubtasksForRange` methods in `TaskSummaryService` to only require the tasks list, removing redundant date filtering and relying on the domain service for status checks.

**Testing/Configuration:**

* Updated the test date range in `src/index.ts` for the range summary example to use new dates.